### PR TITLE
Make setup.py clean for mocktest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,27 +7,49 @@ from setuptools import setup
 
 sys.path.insert(0, '.')
 
-from url_monitor.packaging import (
-    version, authors, emails, license, install_requires,
-    long_description, description, package, url, software_classified
-)
-
 if __name__ == "__main__":
+    package = "url_monitor"
     setup(
         name=package,
-        version=version,
-        author=authors,
-        author_email=emails,
-        url=url,
-        license=license,
+        version="1.0.0",
+        author="Rackspace Inc",
+        author_email="jon.kelley@rackspace.com",
+        url="https://github.com/rackerlabs/zabbix_url_monitor",
+        license="ASLv2",
         packages=[package],
         package_dir={package: package},
-        description=description,
-        long_description=long_description,
-        classifiers=software_classified,
+        description=(
+            'A zabbix plugin to perform URL endpoint monitoring for JSON and XML REST '
+            'APIs, supporting multiple http auth mechinisms'
+        ),
+        long_description=(
+            'A Zabbix plugin written in Python that creates low level discovery items '
+            'containing values from your JSON API. It supports multiple requests auth '
+            'backends including oauth, basicauth, and your even own custom requests '
+            'auth provider plugins. The low level discovery items can generate item '
+            'prototypes which can be used to represent your data through this plugin.'
+        ),
+        classifiers=[
+            'Intended Audience :: System Administrators',
+            'License :: OSI Approved :: Apache Software License',
+            'Natural Language :: English',
+            'Operating System :: OS Independent',
+            'Programming Language :: Python',
+            'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 3',
+            'Topic :: System :: Monitoring',
+            'Topic :: System :: Networking :: Monitoring',
+            'Topic :: System :: Systems Administration ',
+        ],
         entry_points={
             'console_scripts': ['url_monitor = url_monitor.main:main'],
         },
         data_files=[('/etc', ['url_monitor.yaml'])],
-        install_requires=install_requires
+        install_requires=['python-daemon',
+            'requests',
+            'requests-oauthlib',
+            'oauthlib',
+            'argparse',
+            'PyYAML'
+        ]
     )

--- a/url_monitor/packaging.py
+++ b/url_monitor/packaging.py
@@ -29,29 +29,7 @@ authors_string = ', '.join(authors)
 emails = ['jon.kelley@rackspace.com',
           'nick.bales@rackspace.com',
           'landon.jurgens@rackspace.com']
-license = 'ASLv2'
-company = "Rackspace, Inc."
-copyright = '2016 ' + company
 url = 'https://github.com/rackerlabs/zabbix_url_monitor'
-install_requires = ['python-daemon',
-                    'requests',
-                    'requests-oauthlib',
-                    'oauthlib',
-                    'argparse',
-                    'PyYAML'
-                    ]
-software_classified = [
-    'Intended Audience :: System Administrators',
-    'License :: OSI Approved :: Apache Software License',
-    'Natural Language :: English',
-    'Operating System :: OS Independent',
-    'Programming Language :: Python',
-    'Programming Language :: Python :: 2',
-    'Programming Language :: Python :: 3',
-    'Topic :: System :: Monitoring',
-    'Topic :: System :: Networking :: Monitoring',
-    'Topic :: System :: Systems Administration ',
-]
 
 # Internal constants
 # Default assuming networking ports


### PR DESCRIPTION
`setup.py` will need to be independent with its versioning and variables too. 

This will specifically fix this mock failure
```Mock Version: 1.2.14```

```ENTER do(['bash', '--login', '-c', '/usr/bin/rpmbuild -bs --target x86_64 --nodeps /builddir/build/SPECS/url_monitor.spec'], chrootPath='/var/lib/mock/epel-6-x86_64/root'shell=FalseprintOutput=Falseenv={'LANG': 'en_US.UTF-8', 'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\x1b]0;<mock-chroot>\x07<mock-chroot>"', 'HOME': '/builddir', 'CCACHE_DIR': '/tmp/ccache', 'CCACHE_UMASK': '002'}gid=135user='mockbuild'timeout=0logger=<mockbuild.trace_decorator.getLog object at 0x285c2d0>uid=503)```

```Executing command: ['bash', '--login', '-c', '/usr/bin/rpmbuild -bs --target x86_64 --nodeps /builddir/build/SPECS/url_monitor.spec'] with env {'LANG': 'en_US.UTF-8', 'TERM': 'vt100', 'SHELL': '/bin/bash', 'HOSTNAME': 'mock', 'PATH': '/usr/bin:/bin:/usr/sbin:/sbin', 'PROMPT_COMMAND': 'printf "\x1b]0;<mock-chroot>\x07<mock-chroot>"', 'HOME': '/builddir', 'CCACHE_DIR': '/tmp/ccache', 'CCACHE_UMASK': '002'} and shell False```

```Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named url_monitor.metadata```
