### PR TITLE
Correcting refactor issues.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     package = "url_monitor"
     setup(
         name=package,
-        version="1.0.1",
+        version="1.0.2",
         author="Rackspace Inc",
         author_email="jon.kelley@rackspace.com",
         url="https://github.com/rackerlabs/zabbix_url_monitor",

--- a/url_monitor.spec
+++ b/url_monitor.spec
@@ -1,7 +1,7 @@
 %{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Name:           url_monitor
-Version:        1.0.1
+Version:        1.0.2
 Release:        1%{?dist}
 Group:          Applications/Systems
 Summary:        This is an external script for zabbix for monitoring restful endpoints for data.
@@ -53,6 +53,13 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/%{name}
 %attr(0755,-,-) %{_bindir}/%{name}
 
 %changelog
+* Thu Jul 27 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 1.0.2-1
+- Remove misreferenced packaging import(s)
+- Remove {url} from epilog output
+- Make zbx_send timeouts cast into float() from configparser
+- Fix a missing ) in the config parser.
+- Remove __author__ from __init__
+
 * Wed Jul 27 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 1.0.1-1
 - Fix by removing oprhaned references from __init__.py
 

--- a/url_monitor/__init__.py
+++ b/url_monitor/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-__author__ = packaging.authors[0]
-
 # The package name, which is also the "UNIX name" for the project.
 package = 'url_monitor'
 project = "URL Monitor Module"
@@ -17,4 +15,3 @@ authors_string = ', '.join(authors)
 emails = ['jon.kelley@rackspace.com',
           'nick.bales@rackspace.com',
           'landon.jurgens@rackspace.com']
-

--- a/url_monitor/configuration.py
+++ b/url_monitor/configuration.py
@@ -6,7 +6,6 @@ import socket
 
 import yaml
 
-import packaging
 import logging.handlers
 import commons
 

--- a/url_monitor/main.py
+++ b/url_monitor/main.py
@@ -32,8 +32,7 @@ def return_epilog():
     return (
         "{project}\n"
         "{footerline}\n"
-        "{authors}\n"
-        "URL: <{url}>"
+        "{authors}"
     ).format(
         footerline=str('-' * 72),
         project=projectmacro,
@@ -158,7 +157,7 @@ def check(testSet, configinstance, logger):
     z_host, z_port = commons.get_hostport_tuple(
         constant_zabbix_port, config['config']['zabbix']['host'])
 
-    timeout = config['config']['zabbix']['send_timeout']
+    timeout = float(config['config']['zabbix']['send_timeout'])
     # Send metrics to zabbix
     logging.debug(
         "Prepping transmit metrics to zabbix... {metrics}".format(metrics=metrics))
@@ -257,6 +256,7 @@ def main(arguements=None):
         "--version",
         action='version',
         version='UNSUPPORTED OPTION'
+    )
     arg_parser.add_argument(
         "--key",
         "-k",


### PR DESCRIPTION
Unfortunately I caught a few things related to the last commit surrounding the cleanup =/ Fixes.

- Remove misreferenced packaging import(s)
- Remove {url} from epilog output
- Make zbx_send timeouts cast into float() from configparser
- Fix a missing ) in the config parser.
- Remove `__author__` from `__init__`