### PR TITLE
Add support for custom metric  host key in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+## 1.1.3-1 (Sep 19 2016)
+
+Feature:
+
+  - Add support for defining custom zabbix host key item name. (#20, @jonkelleyatrackspace)
+  - Rename zabbix: host to zabbix: server, to make room for new feature. (#20, @jonkelleyatrackspace)
+
+## 1.1.2-2 (Sep 16 2016)
+
+Feature:
+
+  - Adding an stdout message to print the worst return status code seen for a particular set of check(s). (@jonkelleyatrackspace)
+  - Change output info message to only appear in debug, to limit confusion for the status code evaluation. (@jonkelleyatrackspace)
+
+## 1.1.0-1 (Jul 27 2016)
+
+Bugfixes:
+
+  - Fix the --key flag for selective run. (@jonkelleyatrackspace)
+  - Fix the yaml configuration file to meet YAML spec. (@jonkelleyatrackspace)
+
+Docs:
+
+  - Update readme to match new configs (@jonkelleyatrackspace)
+
+## 1.0.2-1 (Jul 27 2016)
+
+Cleanup:
+
+  - Remove misreferenced packaging import(s) (@jonkelleyatrackspace)
+  - Remove {url} from epilog output (@jonkelleyatrackspace)
+  - Remove __author__ from __init__ (@jonkelleyatrackspace)
+
+Bugfixes:
+
+  - Make zbx_send timeouts cast into float() from configparser (@jonkelleyatrackspace)
+  - Fix a missing ) in the config parser. (@jonkelleyatrackspace)
+
+## 1.0.0-1 (Jul 18 2016)
+
+Bugfixes:
+
+  - Fix a bug where missing variable from packaging.py (@jonkelleyatrackspace)
+
+## 0.9.0-1 (Jul 10 2016)
+
+Bugfixes:
+
+  - Added forked process for non interrupting io from zabbix. (@jonkelleyatrackspace)
+  - Many other improvements (@jonkelleyatrackspace)
+
+## 0.8.5-1 (Apr 29 2016)
+
+Bugfixes:
+
+  - Fixes to work better when singleton doesnt take, like on py2.6 (@jonkelleyatrackspace)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     package = "url_monitor"
     setup(
         name=package,
-        version="1.1.2",
+        version="1.1.3",
         author="Rackspace Inc",
         author_email="jon.kelley@rackspace.com",
         url="https://github.com/rackerlabs/zabbix_url_monitor",

--- a/url_monitor.spec
+++ b/url_monitor.spec
@@ -1,7 +1,7 @@
 %{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Name:           url_monitor
-Version:        1.1.2
+Version:        1.1.3
 Release:        1%{?dist}
 Group:          Applications/Systems
 Summary:        This is an external script for zabbix for monitoring restful endpoints for data.

--- a/url_monitor.spec
+++ b/url_monitor.spec
@@ -53,31 +53,8 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/%{name}
 %attr(0755,-,-) %{_bindir}/%{name}
 
 %changelog
-* Fri Sep 16 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 1.1.2-2
-- Add stdout print on exit to match with Zabbix status evaluation
-
-* Thu Aug 2 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 1.1.0-1
-- Fix the --key flag for selective run.
-- Fix the yaml configuration file to meet YAML spec.
-- Update readme to match new configs
-
-* Thu Jul 27 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 1.0.2-1
-- Remove misreferenced packaging import(s)
-- Remove {url} from epilog output
-- Make zbx_send timeouts cast into float() from configparser
-- Fix a missing ) in the config parser.
-- Remove __author__ from __init__
-
-* Wed Jul 27 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 1.0.1-1
-- Fix by removing oprhaned references from __init__.py
-
 * Mon Jul 18 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 1.0.0-1
-- Make spec mock friendly
-- Fix a bug where missing variable from packaging.py
-
-* Fri Jul 10 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 0.9.0-1
-- Added forked process for non interrupting io from zabbix.
-- Many other improvements
+- Spec now mock-build compatible by removing inline py code from spec.
 
 * Fri Apr 29 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 0.8.5-1
-- Fixes to work better when singleton doesnt take, like on py2.6
+- First spec

--- a/url_monitor.yaml
+++ b/url_monitor.yaml
@@ -21,7 +21,8 @@ config:
             oauthv1-oauth_token: ''
             oauthv1-token_secet: ''
   zabbix:
-    host: localhost:10051
+    server: localhost:10051
+    host: zabbix_hostitem_key
     send_timeout: 15
     item_key_format: "url_monitor[{datatype}, {metricname}, {uri}]"
 testSet:

--- a/url_monitor/configuration.py
+++ b/url_monitor/configuration.py
@@ -266,6 +266,7 @@ class ConfigObject(object):
             exit(1)
 
         try:
+            self.config['config']['zabbix']['server']
             self.config['config']['zabbix']['host']
             self.config['config']['zabbix']['send_timeout']
             self.config['config']['zabbix']['item_key_format']

--- a/url_monitor/main.py
+++ b/url_monitor/main.py
@@ -99,6 +99,9 @@ def check(testSet, configinstance, logger):
         logging.exception("Error logging into the ")
         return 1
 
+    # This is the host key defined in your metric.
+    # This matches the name of your host key in the zabbix ui under 'hosts'
+    zabbix_metric_host = config['config']['zabbix']['host']
 
     metrics = []
     # For each testElement do our path check.
@@ -150,12 +153,12 @@ def check(testSet, configinstance, logger):
             metrickey = config['config']['zabbix'][
                 'item_key_format'].format(**element)
 
-            metrics.append(Metric('url_monitor',
+            metrics.append(Metric(zabbix_metric_host,
                                   metrickey,
                                   element['request_response']))
 
     z_host, z_port = commons.get_hostport_tuple(
-        constant_zabbix_port, config['config']['zabbix']['host'])
+        constant_zabbix_port, config['config']['zabbix']['server'])
 
     timeout = float(config['config']['zabbix']['send_timeout'])
     # Send metrics to zabbix


### PR DESCRIPTION

1. Add ability to define your own host keyItem for attaching metrics to in zabbix ui.
2. Split specfile entries off into the program changelog, and leave spec updates in the spec changelog.