### PR TITLE
Fix issue with metrics transmit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.0.1-1 (Oct 31 2016)
+
+Fixes
+
+  - Fixed issue with the transmit function (related) to the major refactor
+  - Fixed a bug on Python 2.6 where logging.handlers.SysLogHandler doesn't support socktype
+
+
 ## 3.0.0-1 (Oct 10 2016)
 
 Major Feature:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     package = "url_monitor"
     setup(
         name=package,
-        version="3.0.0",
+        version="3.0.1",
         author="Rackspace Inc",
         author_email="jon.kelley@rackspace.com",
         url="https://github.com/rackerlabs/zabbix_url_monitor",

--- a/url_monitor.spec
+++ b/url_monitor.spec
@@ -1,7 +1,7 @@
 %{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Name:           url_monitor
-Version:        3.0.0
+Version:        3.0.1
 Release:        1%{?dist}
 Group:          Applications/Systems
 Summary:        This is an external script for zabbix for monitoring restful endpoints for data.
@@ -21,6 +21,7 @@ Requires:       python-requests
 Requires:       python-requests-oauthlib
 Requires:       python-argparse
 Requires:       PyYAML
+Requires:       facterpy
 
 %define service_name %{name}d
 
@@ -53,6 +54,10 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/%{name}
 %attr(0755,-,-) %{_bindir}/%{name}
 
 %changelog
+* Mon Oct 31 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 3.0.1-1
+- Update spec version
+- Add facterpy to requirements (built against facterpy-0.1-1)
+
 * Mon Oct 11 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 3.0.0-1
 - Update spec version
 

--- a/url_monitor/action.py
+++ b/url_monitor/action.py
@@ -8,7 +8,7 @@ import json
 import requests
 from urlparse import urlparse
 
-from zbxsend import Metric
+import zbxsend
 
 __doc__ = """Action on backends after entry points are handled in main"""
 
@@ -47,7 +47,7 @@ def webfacade(testSet, configinstance, webcaller, config):
         return out
 
 
-def transmitfacade(configinstance, metrics):
+def transmitfacade(configinstance, metrics, logger):
     """
     Send a list of Metric objects to zabbix.
     Called by check()
@@ -82,13 +82,13 @@ def transmitfacade(configinstance, metrics):
     )
     logging.info(
         "{m} host {zbxhost}:{zbxport}".format(
-            m=msg, metrics=metrics, zbxhost=z_host, zbxport=z_port
+            m=msg, metrics=metrics, zbxhost=z_host, zbxport=z_port, logger=logger
         )
     )
 
     # Send metrics to zabbix
     try:
-        event.send_to_zabbix(
+        zbxsend.send_to_zabbix(
             metrics=metrics,
             zabbix_host=z_host,
             zabbix_port=z_port,
@@ -195,12 +195,12 @@ def check(testSet, configinstance, logger):
                 'item_key_format'].format(**check)
 
             zabbix_telemetry.append(
-                Metric(zabbix_metric_host, metrickey, check['api_response'])
+                zbxsend.Metric(zabbix_metric_host, metrickey, check['api_response'])
             )
 
     logger.info("Sending telemetry to zabbix server as Metrics objects")
     logger.debug("Telemetry: {0}".format(zabbix_telemetry))
-    if not transmitfacade(configinstance=config, metrics=zabbix_telemetry):
+    if not transmitfacade(configinstance=config, metrics=zabbix_telemetry, logger=logger):
         logger.critical("Sending telemetry to zabbix failed!")
 
     if report_bad_health:

--- a/url_monitor/configuration.py
+++ b/url_monitor/configuration.py
@@ -499,8 +499,8 @@ class ConfigObject(baseConfig, configProperties):
             print("1")
             exit(1)
         if (debug_level.lower().startswith('err') or
-                    debug_level.lower().startswith('exc')
-                ):
+            debug_level.lower().startswith('exc')
+            ):
             return logging.ERROR
         elif debug_level.lower().startswith('crit'):
             return logging.CRITICAL
@@ -603,6 +603,15 @@ class ConfigObject(baseConfig, configProperties):
             try:
                 sysloghandler = logging.handlers.SysLogHandler(
                     address=sysloghost, socktype=socktype)
+            except TypeError:
+                # Py 2.6 doesnt support custom socktypes
+                self.logger.warning("Python 2.6 only supports TCP for syslog"
+                                    "handling, ignoring syslog socket settin"
+                                    "gs.")
+                sysloghandler = logging.handlers.SysLogHandler(
+                    address=sysloghost)
+
+            try:
                 sysloghandler.setLevel(loglevel)
                 self.logger.addHandler(sysloghandler)
                 sysloghandler.setFormatter(formatter)


### PR DESCRIPTION
- Fix issue with metrics transmitter after refactor
- Lockfile should not lock on discover command input, move lock location around
- Bump the release to 3.0.1
- Add version handler for python 2.6
- Add facterpy dependency for rpm auto-resolution for the dependency 