### PR TITLE
Improve lockfile detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.2-1 (Nov 9 2016)
+
+Improvements
+
+  - Improve pidfile name resolution/path resolution handling.
+
 ## 3.0.1-1 (Oct 31 2016)
 
 Fixes

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     package = "url_monitor"
     setup(
         name=package,
-        version="3.0.1",
+        version="3.0.2",
         author="Rackspace Inc",
         author_email="jon.kelley@rackspace.com",
         url="https://github.com/rackerlabs/zabbix_url_monitor",

--- a/url_monitor.spec
+++ b/url_monitor.spec
@@ -1,7 +1,7 @@
 %{!?python_sitelib: %define python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 
 Name:           url_monitor
-Version:        3.0.1
+Version:        3.0.2
 Release:        1%{?dist}
 Group:          Applications/Systems
 Summary:        This is an external script for zabbix for monitoring restful endpoints for data.
@@ -54,6 +54,9 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/%{name}
 %attr(0755,-,-) %{_bindir}/%{name}
 
 %changelog
+* Mon Nov 9 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 3.0.2-1
+- Update spec version
+
 * Mon Oct 31 2016 Jonathan Kelley <jon.kelley@rackspace.com> - 3.0.1-1
 - Update spec version
 - Add facterpy to requirements (built against facterpy-0.1-1)

--- a/url_monitor/commons.py
+++ b/url_monitor/commons.py
@@ -105,12 +105,28 @@ class AcquireRunLock(object):
         """
         Create exclusive app lock
         """
-        if pidfile.startswith("/"):
+
+        # logic lock to ensure the disk format is always "x.pid"
+        # regardless of what the user inputs.
+        # supports both a Fully Qualified File Path as well as assumptive relative pathing
+        # (relying on zabbix server lock dir)
+        if pidfile.startswith("/"): # user defined explicit path
             piddir = os.path.dirname(pidfile)
-            pidpath = pidfile  # use explicit path
-        else:
-            piddir = "/var/lib/zabbixsrv/"
-            pidpath = "{dir}{file}".format(dir=piddir, file=pidfile)
+            if pidfile.endswith(".pid"):
+                # the user provided .pid extension
+                pidpath = ("{0}").format(pidfile)
+            else:
+                # detect/add .pid extension
+                pidpath = ("{0}.pid").format(pidfile)
+
+        else: # relative path, dump pid lock with zabbix i guess?
+            piddir = "/var/run/zabbixsrv"
+            if pidfile.endswith(".pid"):
+                # the user provided .pid extension
+                pidpath = "{dir}/{pidfname}".format(dir=piddir, pidfname=pidfile)
+            else:
+                # detect/add .pid extension
+                pidpath = "{dir}/{pidfname}.pid".format(dir=piddir, pidfname=pidfile)
 
         # Check lockdir exists
         if not os.path.exists(piddir):


### PR DESCRIPTION
Detect and save lockfile in more appropriate location/filenames

Tested locally with these pid filename formats:

- /tmp/xtest
- /tmp/xtest.pid
- /home/jon/xtestpid
- xtest.pid
- xtest