### PR TITLE
Fix RACE condition with lockfile. It works now!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-## 3.0.2-1 (Nov 10 2016)
+## 3.0.3-1 (Nov 11 2016)
+
+Fixes
+
+  - Issue (race condition) in lockfile. Oops.
 
 Improvements
 
   - Improve pidfile name resolution/path resolution handling.
+
+## 3.0.2-1 (Nov 10 2016)
 
 Fixes
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if __name__ == "__main__":
     package = "url_monitor"
     setup(
         name=package,
-        version="3.0.2",
+        version="3.0.3",
         author="Rackspace Inc",
         author_email="jon.kelley@rackspace.com",
         url="https://github.com/rackerlabs/zabbix_url_monitor",


### PR DESCRIPTION
Seems easiest to review in **UNIFIED** DIFF mode

Basically we dropped the else flag....

               if lock.is_locked():
                   logger.critical(
                       " Fail! Process already running with PID {0}. EXECUTION STOP.".format(lock.pid))
                   exit(1)
      -        else:
      -            with lock: # context will .release() automatically
      -                logger.info(
      -                    "PID lock acquired {0} {1}".format(lock.path, lock.pid))
      -

For just the context handler 

               if lock.is_locked():
                   logger.critical(
                       " Fail! Process already running with PID {0}. EXECUTION STOP.".format(lock.pid))
                   exit(1)
      +        with lock:  # context will .release() automatically
      +            logger.info(
      +                "PID lock acquired {0} {1}".format(lock.path, lock.pid))

      +

Code tested in environment
